### PR TITLE
hubspot closed

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ To contribute:
 | Name  |  Location | Application Period | Notes |
 |---|---|-------------|-------------|
 | [Affirm](https://boards.greenhouse.io/affirm/jobs/) | Remote | Not Opened | |
-| [Hubspot](https://www.hubspot.com/careers/jobs?hubs_signup-cta=careers-nav-cta&page=1#office=remote;department=product-ux-engineering;roleType=intern;) | Remote (Canada & US) | Open | |
+| [Hubspot](https://www.hubspot.com/careers/jobs?hubs_signup-cta=careers-nav-cta&page=1#office=remote;department=product-ux-engineering;roleType=intern;) | Remote (Canada & US) | Closed | |
 | [TikTok](https://careers.tiktok.com/position/7047254937289853197/detail) | Mountain View | Open | Application deadline: August 5, 2022 |
 | [Amazon Robotics](https://www.amazon.jobs/en/jobs/1875642/amazon-robotics-software-development-engineer-sde-co-op-fall-2022?cmpid=SPLICX0248M&utm_source=linkedin.com&utm_campaign=cxro&utm_medium=social_media&utm_content=job_posting&ss=paid) | Boston | Open | Must be eligible and available for a full-time (40h / week) 6-month co-op between June to December 2022 |
 | [Anduril](https://jobs.lever.co/anduril/f31aab9c-b194-49e8-ad2a-b7b631d9f8b0) | Seatle, WA OR Costa Mesa, CA | Open ||


### PR DESCRIPTION
Heyo. Looks like hubspot is now closed for SWE roles. 
https://www.hubspot.com/careers/jobs?hubs_signup-cta=careers-nav-cta&page=1#roleType=intern;

Thank you for maintaining this list!