### PR TITLE
update status for carrier and toast

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ To contribute:
 | [Rippling](https://www.rippling.com/careers/4747010003?gh_jid=4747010003) | San Francisco | Closed | Software Engineer Internship - Fall 2022 |
 | [Varda](https://boards.greenhouse.io/vardaspace/jobs/4938904003) | Los Angeles, CA | Open | Software Engineer Internship - Fall 2022; must be a U.S. citizen |
 | [Cockroach Labs](https://www.cockroachlabs.com/careers/jobs/?gh_jid=3860958) | No Location Listed | Closed | Software Engineer Internship - Fall 2022 |
-| [Carrier](https://jobs.carrier.com/job/pittsford/software-developer-fall-2022-co-op/29289/24121299312) | Pittsford, NY | Open | ~~SOFTWARE DEVELOPER FALL 2022 CO-OP~~, still open for [Sustaining Software Engineer Fall 2022 Co-op](https://jobs.carrier.com/job/pittsford/sustaining-software-engineer-fall-2022-co-op/29289/24174954736). US Citizen & Permanent Residents Only |
+| [Carrier](https://jobs.carrier.com/job/pittsford/software-developer-fall-2022-co-op/29289/24121299312) | Pittsford, NY | Closed | ~~SOFTWARE DEVELOPER FALL 2022 CO-OP~~, still open for [Sustaining Software Engineer Fall 2022 Co-op](https://jobs.carrier.com/job/pittsford/sustaining-software-engineer-fall-2022-co-op/29289/24174954736). US Citizen & Permanent Residents Only |
 | [Meta](https://www.metacareers.com/jobs/651492202876559/?rx_campaign=Linkedin1&rx_group=126320&rx_job=a1K2K000008T8f6UAC_aafedf41&rx_medium=post&rx_r=none&rx_source=Linkedin&rx_ts=20220302T180302Z&utm_campaign=Job%2Bboard&utm_medium=jobs&utm_source=LIpaid&rx_viewer=fba0cd739a8511ec87148b7e9558b76885e57e351f9344178adc3d0104db7076) | Remote | Closed | Software Engineer, Intern/Co-Op
 | [Astranis](https://jobs.lever.co/astranis/7abd6407-c1aa-4e96-b3d9-bfb151569342?lever-source=LinkedInJobs) | San Francisco, CA | Open | Ground Software — Intern (Summer/Fall 2022); must be a U.S. Citizen |
 | [Volvo Group](https://xjobs.brassring.com/TGnewUI/Search/home/HomeWithPreLoad?PageType=JobDetails&partnerid=25079&siteid=5171&AReq=122433BR&codes=LinkedIn#jobDetails=731162_5171) | U.S. | Open | Intern: Software Engineering (Fall 2022) |
@@ -79,7 +79,7 @@ To contribute:
 | [IBM](https://careers.ibm.com/job/14818791/technical-support-developer-co-op-summer-fall-2022-san-jose-ca/?codes=IBM_CareerWebSite) | San Jose| Closed | Technical Support Developer Co-op (Summer + Fall 2022) |
 | [Amazon.com LLC](https://www.amazon.jobs/en/jobs/2013931/software-development-engineer-internship-fall-2022-us) | U.S. | Open | Software Development Engineer Internship - Fall 2022 (US), Job ID: 2013931 |
 | [Kodiak Robotics](https://jobs.lever.co/kodiak) | Mountain View, CA | Open | Fall 2022 Intern, Deep Learning for Computer Vision; Fall 2022 Intern, Perception; Fall 2022 Software Internship |
-| [Toast](https://careers.toasttab.com/jobs/software-engineer-co-op-fall-2022-remote-united-states) | Remote | Open | Software Engineer Co-op: Fall 2022 |
+| [Toast](https://careers.toasttab.com/jobs/software-engineer-co-op-fall-2022-remote-united-states) | Remote | Closed | Software Engineer Co-op: Fall 2022 |
 | [Wayfair](https://www.wayfair.com/careers/job/software-engineering-co-op---july-2022/5822320002/apply) | Boston, MA | Open | 6-month Software Engineering Co-op from July 11th, 2022-December 16th, 2022 |
 | [Leidos](https://careers.leidos.com/jobs/8600490-engineering-co-op-summer-slash-fall-2022) | Bethesda, MD | Open | Must be available to work at least 6 months full time as a co-op,  U.S. Citizenship and eligibility to obtain a U.S. Government granted security clearance is needed|
 


### PR DESCRIPTION
Both internships @ [Carrier](https://jobs.carrier.com/job/pittsford/sustaining-software-engineer-fall-2022-co-op/29289/24174954736) and [Toast](https://careers.toasttab.com/jobs/software-engineer-co-op-fall-2022-remote-united-states) are closed now.